### PR TITLE
Update Django dependency to be up to 2.2 (excluded)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.rst')
 
 
 DEPENDENCIES = [
-    'django >=1.6, <=2.1',
+    'django >=1.6, <2.2',
     'funcy',
 ]
 


### PR DESCRIPTION
Makes it compatible with Django 2.1 minor releases