### PR TITLE
Remove external funcy dependencies

### DIFF
--- a/abnorm/adapters/django1p6.py
+++ b/abnorm/adapters/django1p6.py
@@ -1,7 +1,5 @@
 import sys
 
-from funcy import first
-
 from django.db import models
 from django.db.models.loading import get_model
 from django.contrib.contenttypes.generic import (
@@ -118,11 +116,11 @@ class SpecificDjango(EveryDjango):
         elif isinstance(rf, ManyToManyField):
             return rf.related.get_accessor_name()
         elif isinstance(rf, GenericRelation):
-            return first([
+            return next(iter([
                 f for f in self.get_model_fields(
                     descriptor.field.rel.to)
                 if self._is_matching_generic_foreign_key(descriptor.field, f)
-            ]).name
+            ]), None).name
 
     def get_model(self, app_label, model_name=None):
         if model_name is None:

--- a/abnorm/adapters/django1p6.py
+++ b/abnorm/adapters/django1p6.py
@@ -116,11 +116,10 @@ class SpecificDjango(EveryDjango):
         elif isinstance(rf, ManyToManyField):
             return rf.related.get_accessor_name()
         elif isinstance(rf, GenericRelation):
-            return next(iter([
-                f for f in self.get_model_fields(
-                    descriptor.field.rel.to)
+            return [
+                f for f in self.get_model_fields(descriptor.field.rel.to)
                 if self._is_matching_generic_foreign_key(descriptor.field, f)
-            ]), None).name
+            ][0].name
 
     def get_model(self, app_label, model_name=None):
         if model_name is None:

--- a/abnorm/adapters/django1p7.py
+++ b/abnorm/adapters/django1p7.py
@@ -126,11 +126,10 @@ class SpecificDjango(EveryDjango):
         elif isinstance(rf, ManyToManyField):
             return rf.related.get_accessor_name()
         elif isinstance(rf, GenericRelation):
-            return next(iter([
-                f for f in self.get_model_fields(
-                    descriptor.field.rel.to)
+            return [
+                f for f in self.get_model_fields(descriptor.field.rel.to)
                 if self._is_matching_generic_foreign_key(descriptor.field, f)
-            ]), None).name
+            ][0].name
 
     def _is_matching_generic_foreign_key(self, descriptor_field, field):
         """

--- a/abnorm/adapters/django1p7.py
+++ b/abnorm/adapters/django1p7.py
@@ -1,7 +1,5 @@
 import sys
 
-from funcy import first
-
 from django.db import models
 from django.apps import apps
 from django.utils import six
@@ -128,11 +126,11 @@ class SpecificDjango(EveryDjango):
         elif isinstance(rf, ManyToManyField):
             return rf.related.get_accessor_name()
         elif isinstance(rf, GenericRelation):
-            return first([
+            return next(iter([
                 f for f in self.get_model_fields(
                     descriptor.field.rel.to)
                 if self._is_matching_generic_foreign_key(descriptor.field, f)
-            ]).name
+            ]), None).name
 
     def _is_matching_generic_foreign_key(self, descriptor_field, field):
         """

--- a/abnorm/adapters/django1p8.py
+++ b/abnorm/adapters/django1p8.py
@@ -1,5 +1,3 @@
-from funcy import first
-
 from .django1p7 import SpecificDjango as Django1p7
 
 
@@ -58,11 +56,11 @@ class SpecificDjango(Django1p7):
         elif isinstance(rf, ManyToManyField):
             return rf.related.get_accessor_name()
         elif isinstance(rf, GenericRelation):
-            return first([
+            return next(iter([
                 f for f in self.get_model_fields(
                     descriptor.field.related_model)
                 if self._is_matching_generic_foreign_key(descriptor.field, f)
-            ]).name
+            ]), None).name
 
     def get_model_fields(self, model):
         return model._meta.get_fields(include_hidden=True)

--- a/abnorm/adapters/django1p8.py
+++ b/abnorm/adapters/django1p8.py
@@ -56,11 +56,11 @@ class SpecificDjango(Django1p7):
         elif isinstance(rf, ManyToManyField):
             return rf.related.get_accessor_name()
         elif isinstance(rf, GenericRelation):
-            return next(iter([
+            return [
                 f for f in self.get_model_fields(
                     descriptor.field.related_model)
                 if self._is_matching_generic_foreign_key(descriptor.field, f)
-            ]), None).name
+            ][0].name
 
     def get_model_fields(self, model):
         return model._meta.get_fields(include_hidden=True)

--- a/abnorm/adapters/django1p9.py
+++ b/abnorm/adapters/django1p9.py
@@ -1,5 +1,3 @@
-from funcy import first
-
 from .django1p8 import SpecificDjango as Django1p8
 
 
@@ -100,8 +98,8 @@ class SpecificDjango(Django1p8):
         elif isinstance(rf, ManyToManyField):
             return rf.remote_field.get_accessor_name()
         elif isinstance(rf, GenericRelation):
-            return first([
+            return next(iter([
                 f for f in self.get_model_fields(
                     descriptor.field.related_model)
                 if self._is_matching_generic_foreign_key(descriptor.field, f)
-            ]).name
+            ]), None).name

--- a/abnorm/adapters/django1p9.py
+++ b/abnorm/adapters/django1p9.py
@@ -98,8 +98,8 @@ class SpecificDjango(Django1p8):
         elif isinstance(rf, ManyToManyField):
             return rf.remote_field.get_accessor_name()
         elif isinstance(rf, GenericRelation):
-            return next(iter([
+            return [
                 f for f in self.get_model_fields(
                     descriptor.field.related_model)
                 if self._is_matching_generic_foreign_key(descriptor.field, f)
-            ]), None).name
+            ][0].name

--- a/abnorm/fields.py
+++ b/abnorm/fields.py
@@ -13,7 +13,7 @@ from django.utils import six
 from django.core.exceptions import ObjectDoesNotExist
 
 from .adapters import this_django, south
-from .utils import get_model_name, dumps, loads
+from .utils import get_model_name, dumps, loads, first
 from . import state
 
 
@@ -138,7 +138,7 @@ class DenormalizedFieldMixin(object):
                 ),
                 this_django.get_model_fields(rel_model)
             )
-            related_field = next(iter(generic_fk_fields), None)
+            related_field = first(generic_fk_fields)
             related_field_name = getattr(related_field, 'name', None)
         else:
             related_field_name = descriptor_field.name

--- a/abnorm/management/commands/update_abnorm_fields.py
+++ b/abnorm/management/commands/update_abnorm_fields.py
@@ -1,6 +1,6 @@
 import gc
 
-from funcy import distinct, group_values
+from collections import defaultdict
 
 from django.core.management.base import BaseCommand
 from django.db import transaction
@@ -47,8 +47,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # django 1.6/1.7 takes cmd args as `args`, 1.8+ as `options`
         # sum their values to support both ways
-        fields = distinct(list(args) + options.get('field', []))
-        groups = group_values(f.rsplit('.', 1) for f in fields)
+        fields = set(list(args) + options.get('field', []))
+        groups = defaultdict(list)
+        for f in fields:
+            splitted_field = f.rsplit('.', 1)
+            groups[splitted_field[0]].extend(splitted_field[1:])
         for model_name, field_names in groups.items():
             self.migrate_fields(model_name, field_names)
 

--- a/abnorm/utils.py
+++ b/abnorm/utils.py
@@ -24,3 +24,7 @@ def loads(txt):
         encoding=settings.DEFAULT_CHARSET
     )
     return value
+
+
+def first(iterable):
+    return next(iter(iterable), None)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ README = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.rst')
 
 DEPENDENCIES = [
     'django >=1.6, <2.2',
-    'funcy',
 ]
 
 


### PR DESCRIPTION
It is necessary to keep as little as possible external dependencies.
`funcy `doesn't make the code much easier.